### PR TITLE
Remove network calls from rendering `App` in tests

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -43,6 +43,7 @@
     "prettier": "3.2.4",
     "typescript": "^5.2.2",
     "vite": "^5.0.8",
-    "vitest": "^1.2.1"
+    "vitest": "^1.2.1",
+    "wonka": "^6.3.4"
   }
 }

--- a/ui/src/App.test.tsx
+++ b/ui/src/App.test.tsx
@@ -1,8 +1,0 @@
-import { render, screen } from "@testing-library/react";
-import App from "./App";
-
-test("renders logo prompt", () => {
-  render(<App />);
-  const logoPromptText = screen.getByText(/Click on the Vite and React logos/i);
-  expect(logoPromptText).toBeInTheDocument();
-});

--- a/ui/src/Birthday.test.tsx
+++ b/ui/src/Birthday.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from "@testing-library/react";
+import { Provider } from "urql";
+import { Birthday } from "./Birthday";
+import { fromValue } from "wonka";
+
+describe("on load", () => {
+  const responseState = {
+    executeQuery: () =>
+      fromValue({
+        data: {
+          Character: {
+            name: { full: "Character A" },
+            media: { nodes: [{ title: { romaji: "Anime A" } }] },
+          },
+        },
+      }),
+  };
+
+  test("renders birthday character's name", () => {
+    render(
+      <Provider value={responseState}>
+        <Birthday />
+      </Provider>,
+    );
+    const linkElement = screen.getByText(/Character A's birthday/i);
+    expect(linkElement).toBeInTheDocument();
+  });
+
+  test("renders character's source media", () => {
+    render(
+      <Provider value={responseState}>
+        <Birthday />
+      </Provider>,
+    );
+    const linkElement = screen.getByText(/\(from "Anime A"\)/i);
+    expect(linkElement).toBeInTheDocument();
+  });
+});

--- a/ui/src/setupTests.ts
+++ b/ui/src/setupTests.ts
@@ -1,7 +1,20 @@
-import { afterEach } from "vitest";
+import { afterEach, vi, MockInstance } from "vitest";
 import { cleanup } from "@testing-library/react";
 import "@testing-library/jest-dom";
 
+let mockedFetch: MockInstance<any>;
+
+beforeEach(() => {
+  mockedFetch = vi.spyOn(window, "fetch").mockImplementation((...args) => {
+    console.warn(
+      "`window.fetch` is not mocked for this test. Instead, test should render the component in a custom urql provider.",
+      ...args,
+    );
+    return Promise.reject(new Error("`window.fetch` is not mocked"));
+  });
+});
+
 afterEach(() => {
+  mockedFetch.mockReset();
   cleanup();
 });

--- a/ui/src/setupTests.ts
+++ b/ui/src/setupTests.ts
@@ -15,6 +15,11 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  // Required to enforce that fetch was not called, as React Query can gracefully handle fetch errors
+  expect(mockedFetch).not.toHaveBeenCalled();
+});
+
+afterEach(() => {
   mockedFetch.mockReset();
   cleanup();
 });

--- a/ui/src/setupTests.ts
+++ b/ui/src/setupTests.ts
@@ -15,11 +15,6 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  // Required to enforce that fetch was not called, as React Query can gracefully handle fetch errors
-  expect(mockedFetch).not.toHaveBeenCalled();
-});
-
-afterEach(() => {
   mockedFetch.mockReset();
   cleanup();
 });

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -4444,7 +4444,7 @@ why-is-node-running@^2.2.2:
     siginfo "^2.0.0"
     stackback "0.0.2"
 
-wonka@^6.3.2:
+wonka@^6.3.2, wonka@^6.3.4:
   version "6.3.4"
   resolved "https://registry.yarnpkg.com/wonka/-/wonka-6.3.4.tgz#76eb9316e3d67d7febf4945202b5bdb2db534594"
   integrity sha512-CjpbqNtBGNAeyNS/9W6q3kSkKE52+FjIj7AkFlLr11s/VWGUu6a2CdYSdGxocIhIVjaW/zchesBQUKPVU69Cqg==


### PR DESCRIPTION
Drop default create-react-app test on `App.tsx` and add a couple simple tests to `Birthday.tsx` that use a stub provider for `uqrl` to avoid network calls from the real web client-based provider in `App.tsx`. Also, add a fallback mock of `window.fetch` to ensure that no network calls ever slip through from the test runner.

@rstoutamore this may conflict with the create-react-app to vite migration, so let me know if you'd like me to hold off on merging this.